### PR TITLE
Remove in-band-lifetimes, because it's deprecated.

### DIFF
--- a/src/db/caching_int_map.rs
+++ b/src/db/caching_int_map.rs
@@ -65,7 +65,7 @@ impl CachingIntMap {
         }
     }
     // very shitty code. spent 2 hours figuring out how to do this get method generically
-    pub async fn get_bind2(&'c self, key: &'c str, bind1: i64, bind2: i64) -> i64 {
+    pub async fn get_bind2<'c>(&'c self, key: &'c str, bind1: i64, bind2: i64) -> i64 {
         let i: Option<i64> = self.lru.write().await.get(key).copied();
 
         match i {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(in_band_lifetimes)]
 #![feature(proc_macro_hygiene, decl_macro)]
 #![warn(clippy::print_stdout)]
 


### PR DESCRIPTION
Tracking [issue](https://github.com/rust-lang/rust/issues/44524).